### PR TITLE
Extend YAML Schema for League-specific Content

### DIFF
--- a/items/amulets/Ashes of the Stars.yml
+++ b/items/amulets/Ashes of the Stars.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Eater of Worlds
     uber: true
     frequency: uncommon
+    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        - name: Devouring Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/amulets/Ashes of the Stars.yml
+++ b/items/amulets/Ashes of the Stars.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Devouring Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/amulets/Crystallised Omniscience.yml
+++ b/items/amulets/Crystallised Omniscience.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Blazing Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/amulets/Crystallised Omniscience.yml
+++ b/items/amulets/Crystallised Omniscience.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Searing Exarch
     uber: true
     frequency: rare
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       type: bossToken
       components:
-        name: Blazing Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+        - name: Blazing Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/amulets/Stranglegasp.yml
+++ b/items/amulets/Stranglegasp.yml
@@ -4,7 +4,7 @@ acquisitionMethods:
     text: Unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: extremely-rare
     consumable:
-      - type: map
+      - category: map
         name: Blight-Ravaged Map
         text: Blight-Ravaged maps can be obtained by completing tier 13+ Blighted Maps.
         wiki: https://www.poewiki.net/wiki/Blight-ravaged_map

--- a/items/amulets/Stranglegasp.yml
+++ b/items/amulets/Stranglegasp.yml
@@ -4,7 +4,7 @@ acquisitionMethods:
     text: Unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: extremely-rare
     consumable:
-      - category: map
-        name: Blight-Ravaged Map
-        text: Blight-Ravaged maps can be obtained by completing tier 13+ Blighted Maps.
-        wiki: https://www.poewiki.net/wiki/Blight-ravaged_map
+      type: map
+      name: Blight-Ravaged Map
+      text: Blight-Ravaged maps can be obtained by completing tier 13+ Blighted Maps.
+      wiki: https://www.poewiki.net/wiki/Blight-ravaged_map

--- a/items/amulets/Stranglegasp.yml
+++ b/items/amulets/Stranglegasp.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: Unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: extremely-rare
+    consumable:
+      - type: map
+        name: Blight-Ravaged Map
+        text: Blight-Ravaged maps can be obtained by completing tier 13+ Blighted Maps.
+        wiki: https://www.poewiki.net/wiki/Blight-ravaged_map

--- a/items/amulets/Stranglegasp.yml
+++ b/items/amulets/Stranglegasp.yml
@@ -1,10 +1,10 @@
 acquisitionMethods:
   - type: leagueContent
     leagueName: Blight
-    text: Unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    text: Stranglegasp has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: extremely-rare
     consumable:
       type: map
-      name: Blight-Ravaged Map
-      text: Blight-Ravaged maps can be obtained by completing tier 13+ Blighted Maps.
+      name: Blight-ravaged map
+      text: Blight-ravaged maps can be obtained by completing tier 13+ Blighted Maps.
       wiki: https://www.poewiki.net/wiki/Blight-ravaged_map

--- a/items/amulets/The Utmost.yml
+++ b/items/amulets/The Utmost.yml
@@ -3,20 +3,21 @@ acquisitionMethods:
     text: "This unique can be assembled in your inventory from the following components:"
     referenceLink: https://www.poewiki.net/wiki/The_Utmost
     consumable:
+      type: uniqueComponents
       components:
         - name: Curio of Absorption
-          quanitity: 1
+          quantity: 1
           text: Rare drop from Uber Searing Exarch
           wiki: https://www.poewiki.net/wiki/Curio_of_Absorption
         - name: Curio of Decay
-          quanitity: 1
+          quantity: 1
           text: Rare drop from Uber Uber Elder
           wiki: https://www.poewiki.net/wiki/Curio_of_Decay
         - name: Curio of Potential
-          quanitity: 1
+          quantity: 1
           text: Rare drop from Uber Maven
           wiki: https://www.poewiki.net/wiki/Curio_of_Potential
         - name: Curio of Consumption
-          quanitity: 1
+          quantity: 1
           text: Rare drop from Uber Eater of Worlds
           wiki: https://www.poewiki.net/wiki/Curio_of_Consumption

--- a/items/amulets/The Utmost.yml
+++ b/items/amulets/The Utmost.yml
@@ -1,6 +1,7 @@
 acquisitionMethods:
   - type: plainText
-    text: "The Utmost can be assembled in your inventory from the following components:"
+    text: "This unique can be assembled in your inventory from the following components:"
+    referenceLink: https://www.poewiki.net/wiki/The_Utmost
     consumable:
       components:
         - name: Curio of Absorption
@@ -19,4 +20,3 @@ acquisitionMethods:
           quanitity: 1
           text: Rare drop from Uber Eater of Worlds
           wiki: https://www.poewiki.net/wiki/Curio_of_Consumption
-    wiki: https://www.poewiki.net/wiki/The_Utmost

--- a/items/amulets/The Utmost.yml
+++ b/items/amulets/The Utmost.yml
@@ -1,0 +1,22 @@
+acquisitionMethods:
+  - type: plainText
+    text: "The Utmost can be assembled in your inventory from the following components:"
+    consumable:
+      components:
+        - name: Curio of Absorption
+          quanitity: 1
+          text: Rare drop from Uber Searing Exarch
+          wiki: https://www.poewiki.net/wiki/Curio_of_Absorption
+        - name: Curio of Decay
+          quanitity: 1
+          text: Rare drop from Uber Uber Elder
+          wiki: https://www.poewiki.net/wiki/Curio_of_Decay
+        - name: Curio of Potential
+          quanitity: 1
+          text: Rare drop from Uber Maven
+          wiki: https://www.poewiki.net/wiki/Curio_of_Potential
+        - name: Curio of Consumption
+          quanitity: 1
+          text: Rare drop from Uber Eater of Worlds
+          wiki: https://www.poewiki.net/wiki/Curio_of_Consumption
+    wiki: https://www.poewiki.net/wiki/The_Utmost

--- a/items/body-armours/Sporeguard.yml
+++ b/items/body-armours/Sporeguard.yml
@@ -5,6 +5,6 @@ acquisitionMethods:
     frequency: extremely-rare
     consumable:
       type: map
-      name: Blight-ravaged map
-      text: Blight-ravaged maps can be obtained by completing tier 13+ Blighted Maps.
-      wiki: https://www.poewiki.net/wiki/Blight-ravaged_map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/boots/Annihilation's Approach.yml
+++ b/items/boots/Annihilation's Approach.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Blazing Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/boots/Annihilation's Approach.yml
+++ b/items/boots/Annihilation's Approach.yml
@@ -1,13 +1,13 @@
 acquisitionMethods:
   - type: boss
-    boss: The Eater of Worlds
+    boss: The Searing Exarch
     uber: true
     frequency: uncommon
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
+        name: Blazing Fragment
         quanitity: 5
         text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops

--- a/items/boots/Annihilation's Approach.yml
+++ b/items/boots/Annihilation's Approach.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Searing Exarch
     uber: true
     frequency: uncommon
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       type: bossToken
       components:
-        name: Blazing Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+        - name: Blazing Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/boots/The Stampede.yml
+++ b/items/boots/The Stampede.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: common
+    consumable:
+      type: map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/gloves/Breathstealer.yml
+++ b/items/gloves/Breathstealer.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: common
+    consumable:
+      type: map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/gloves/The Celestial Brace.yml
+++ b/items/gloves/The Celestial Brace.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Blazing Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/gloves/The Celestial Brace.yml
+++ b/items/gloves/The Celestial Brace.yml
@@ -1,13 +1,13 @@
 acquisitionMethods:
   - type: boss
-    boss: The Eater of Worlds
+    boss: The Searing Exarch
     uber: true
     frequency: uncommon
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
+        name: Blazing Fragment
         quanitity: 5
         text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops

--- a/items/gloves/The Celestial Brace.yml
+++ b/items/gloves/The Celestial Brace.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Searing Exarch
     uber: true
     frequency: uncommon
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       type: bossToken
       components:
-        name: Blazing Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+        - name: Blazing Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/helmets/Cowl of the Ceraunophile.yml
+++ b/items/helmets/Cowl of the Ceraunophile.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: uncommon
+    consumable:
+      type: map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/helmets/Cowl of the Cryophile.yml
+++ b/items/helmets/Cowl of the Cryophile.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: uncommon
+    consumable:
+      type: map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/helmets/Cowl of the Thermophile.yml
+++ b/items/helmets/Cowl of the Thermophile.yml
@@ -1,0 +1,10 @@
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: uncommon
+    consumable:
+      type: map
+      name: Blighted map
+      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+      wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/helmets/Ravenous Passion.yml
+++ b/items/helmets/Ravenous Passion.yml
@@ -2,7 +2,7 @@ acquisitionMethods:
   - type: boss
     boss: The Eater of Worlds
     uber: true
-    frequency: uncommon
+    frequency: common
     consumable:
       type: bossToken
       components:

--- a/items/helmets/Ravenous Passion.yml
+++ b/items/helmets/Ravenous Passion.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Eater of Worlds
     uber: true
     frequency: common
+    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        - name: Devouring Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/helmets/Ravenous Passion.yml
+++ b/items/helmets/Ravenous Passion.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Devouring Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/jewels/Forbidden Flame.yml
+++ b/items/jewels/Forbidden Flame.yml
@@ -1,8 +1,15 @@
 acquisitionMethods:
   - type: boss
     boss: The Searing Exarch
+    variantName: Passive tree ascendancies
+    frequency: uncommon
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+
+  - type: boss
+    boss: The Searing Exarch
     uber: true
-    frequency: rare
+    variantName: Jewel-only ascendancies
+    frequency: extremely-rare
     consumable:
       type: bossToken
       components:

--- a/items/jewels/Forbidden Flame.yml
+++ b/items/jewels/Forbidden Flame.yml
@@ -10,11 +10,11 @@ acquisitionMethods:
     uber: true
     variantName: Jewel-only ascendancies
     frequency: extremely-rare
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       type: bossToken
       components:
-        name: Blazing Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+        - name: Blazing Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/jewels/Forbidden Flame.yml
+++ b/items/jewels/Forbidden Flame.yml
@@ -15,6 +15,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Blazing Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/jewels/Forbidden Flesh.yml
+++ b/items/jewels/Forbidden Flesh.yml
@@ -1,8 +1,15 @@
 acquisitionMethods:
   - type: boss
     boss: The Eater of Worlds
-    uber: true
+    variantName: Passive tree ascendancies
     frequency: uncommon
+    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+
+  - type: boss
+    boss: The Eater of Worlds
+    uber: true
+    variantName: Jewel-only ascendancies
+    frequency: extremely-rare
     consumable:
       type: bossToken
       components:

--- a/items/jewels/Forbidden Flesh.yml
+++ b/items/jewels/Forbidden Flesh.yml
@@ -10,11 +10,11 @@ acquisitionMethods:
     uber: true
     variantName: Jewel-only ascendancies
     frequency: extremely-rare
+    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        - name: Devouring Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/jewels/Forbidden Flesh.yml
+++ b/items/jewels/Forbidden Flesh.yml
@@ -15,6 +15,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Devouring Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/rings/Nimis.yml
+++ b/items/rings/Nimis.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Eater of Worlds
     uber: true
     frequency: rare
+    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
     consumable:
       type: bossToken
       components:
-        name: Devouring Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Devouring_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
+        - name: Devouring Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/rings/Nimis.yml
+++ b/items/rings/Nimis.yml
@@ -2,7 +2,7 @@ acquisitionMethods:
   - type: boss
     boss: The Eater of Worlds
     uber: true
-    frequency: uncommon
+    frequency: rare
     consumable:
       type: bossToken
       components:

--- a/items/rings/Nimis.yml
+++ b/items/rings/Nimis.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Devouring Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Devouring_Fragment

--- a/items/staves/The Annihilating Light.yml
+++ b/items/staves/The Annihilating Light.yml
@@ -8,6 +8,6 @@ acquisitionMethods:
       type: bossToken
       components:
         - name: Blazing Fragment
-          quanitity: 5
+          quantity: 5
           text: Available from T17 Map Bosses
           wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/staves/The Annihilating Light.yml
+++ b/items/staves/The Annihilating Light.yml
@@ -3,11 +3,11 @@ acquisitionMethods:
     boss: The Searing Exarch
     uber: true
     frequency: common
+    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       type: bossToken
       components:
-        name: Blazing Fragment
-        quanitity: 5
-        text: Available from T17 Map Bosses
-        wiki: https://www.poewiki.net/wiki/Blazing_Fragment
-    wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
+        - name: Blazing Fragment
+          quanitity: 5
+          text: Available from T17 Map Bosses
+          wiki: https://www.poewiki.net/wiki/Blazing_Fragment

--- a/items/staves/The Annihilating Light.yml
+++ b/items/staves/The Annihilating Light.yml
@@ -2,7 +2,7 @@ acquisitionMethods:
   - type: boss
     boss: The Searing Exarch
     uber: true
-    frequency: rare
+    frequency: common
     consumable:
       type: bossToken
       components:

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -294,7 +294,7 @@
                         "bossToken",
                         "scarab",
                         "map",
-                        "uniqueComponent"
+                        "uniqueComponents"
                     ]
                 },
                 "name": {

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -303,6 +303,7 @@
                     "minLength": 1
                 },
                 "components": {
+                    "type": "object",
                     "properties": {
                         "component": {
                             "type": "array",

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -332,7 +332,7 @@
                 },
                 "quantity": {
                     "type": "number",
-                    "minValue": 1
+                    "minimum": 1
                 }
             }
         },

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -259,6 +259,9 @@
                             "text": {
                                 "type": "string",
                                 "minLength": 1
+                            },                            
+                            "consumable": {
+                                "$ref": "#/$defs/consumable"
                             },
                             "referenceLink": {
                                 "anyOf": [
@@ -303,25 +306,31 @@
                     "minLength": 1
                 },
                 "components": {
-                    "type": "object",
-                    "properties": {
-                        "component": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "$ref": "#/$defs/consumableComponent"
-                            }
-                        }
-                    }                    
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/$defs/consumableComponent"
+                    }
                 },
                 "wiki": {
                     "$ref": "#/$defs/wikiLink"
                 }
             },
             "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required" : [
+                        "name"
+                    ]
+                },
+                {
+                    "required" : [
+                        "components"
+                    ]
+                }
+            ],
             "required": [
-                "type",
-                "name"
+                "type"
             ]
         },
         "consumableComponent": {
@@ -334,8 +343,16 @@
                 "quantity": {
                     "type": "number",
                     "minimum": 1
+                },
+                "text": "string",
+                "wiki": {
+                    "$ref": "#/$defs/wikiLink"
                 }
-            }
+            },
+            "required": [
+                "name",
+                "quantity"
+            ]
         },
         "wikiLink": {
             "type": "string",

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -284,7 +284,7 @@
             "title": "Consumable item",
             "description": "An item which is consumed in order to access or alter specific content",
             "properties": {
-                "category": {
+                "type": {
                     "$comment": "Indicates the type of consumable item",
                     "enum": [
                         "leagueItem",
@@ -319,7 +319,7 @@
             },
             "additionalProperties": false,
             "required": [
-                "category",
+                "type",
                 "name"
             ]
         },

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -343,8 +343,11 @@
                 "quantity": {
                     "type": "number",
                     "minimum": 1
+                },                
+                "text": {
+                    "type": "string",
+                    "minLength": 1
                 },
-                "text": "string",
                 "wiki": {
                     "$ref": "#/$defs/wikiLink"
                 }

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -280,12 +280,11 @@
             ]
         },
         "consumable": {
+            "type": "object",
             "title": "Consumable item",
             "description": "An item which is consumed in order to access or alter specific content",
-            "type": "object",
-            "unevaluatedProperties": false,
             "properties": {
-                "type": {
+                "category": {
                     "$comment": "Indicates the type of consumable item",
                     "enum": [
                         "leagueItem",
@@ -318,8 +317,9 @@
                     "$ref": "#/$defs/wikiLink"
                 }
             },
+            "additionalProperties": false,
             "required": [
-                "type",
+                "category",
                 "name"
             ]
         },

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -65,6 +65,7 @@
                         "typicalDivCardFarm",
                         "boss",
                         "vendorRecipe",
+                        "leagueContent",
                         "plainText"
                     ]
                 }
@@ -152,6 +153,9 @@
                                     "extremely-rare"
                                 ]
                             },
+                            "consumable": {
+                                "$ref": "#/$defs/consumable"
+                            },
                             "wiki": {
                                 "$ref": "#/$defs/wikiLink"
                             }
@@ -198,6 +202,49 @@
                     "if": {
                         "properties": {
                             "type": {
+                                "const": "leagueContent"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "title": "League-specific content",
+                        "description": "Details an aquisition method which relies on league-specific content",
+                        "properties": {
+                            "leagueName": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "text": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "frequency": {
+                                "enum": [
+                                    "common",
+                                    "uncommon",
+                                    "rare",
+                                    "extremely-rare"
+                                ]
+                            },
+                            "consumable": {
+                                "$ref": "#/$defs/consumable"
+                            },
+                            "wiki": {
+                                "$ref": "#/$defs/wikiLink"
+                            }
+                        },
+                        "required": [
+                            "leagueName"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
                                 "const": "plainText"
                             }
                         },
@@ -231,6 +278,63 @@
                     }
                 }
             ]
+        },
+        "consumable": {
+            "title": "Consumable item",
+            "description": "An item which is consumed in order to access or alter specific content",
+            "type": "object",
+            "unevaluatedProperties": false,
+            "properties": {
+                "type": {
+                    "$comment": "Indicates the type of consumable item",
+                    "enum": [
+                        "leagueItem",
+                        "bossToken",
+                        "scarab",
+                        "map",
+                        "uniqueComponent"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "text": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "components": {
+                    "properties": {
+                        "component": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/consumableComponent"
+                            }
+                        }
+                    }                    
+                },
+                "wiki": {
+                    "$ref": "#/$defs/wikiLink"
+                }
+            },
+            "required": [
+                "type",
+                "name"
+            ]
+        },
+        "consumableComponent": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "quantity": {
+                    "type": "number",
+                    "minValue": 1
+                }
+            }
         },
         "wikiLink": {
             "type": "string",


### PR DESCRIPTION
- Extend schema to add the "leagueContent" acquisitionMethod
- Add a definition for a "consumable"
- Add a definition for a "consumableComponent"
- Amend "boss" and "plainText" acquisitionMethods to add consumable field
- Add Blight Uniques
- Add Uber Searing Exarch uniques
- Add Uber Eater of Worlds uniques
- Add "The Utmost" unique