### PR TITLE
Reusable consumables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run validation and composing script
         run: |
           pipenv run python builder/run.py \
-            -i items -is schemas/single-item.schema.json \
+            -i items -is schemas/single-item.schema.json -csg 'schemas/common/*.schema.json' \
             -o build/item-data.json -co github-pr-comment.txt
 
       - name: Upload compiled item data as build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Run validation and composing script
         run: |
           pipenv run python builder/run.py \
-            -i items -is schemas/single-item.schema.json -csg 'schemas/common/*.schema.json' \
+            -i items -c consumables \
+            -is schemas/single-item.schema.json -csg 'schemas/common/*.schema.json' \
             -o build/item-data.json -co github-pr-comment.txt
 
       - name: Upload compiled item data as build artifact

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ build/
 node_modules/
 *.json
 !.vscode/*.json
-!schemas/*.json
+!schemas/**/*.json
 github-pr-comment.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 build/
 node_modules/
 *.json
+!.vscode/*.json
 !schemas/*.json
 github-pr-comment.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "yaml.schemas": {
-        "schemas/single-item.schema.json": "items/**/*.yml"
+        "schemas/single-item.schema.json": "items/**/*.yml",
+        "schemas/internal/consumable-map.schema.json": "consumables/**/*.yml"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "schemas/single-item.schema.json": "items/**/*.yml"
+    }
+}

--- a/builder/reporting.py
+++ b/builder/reporting.py
@@ -1,0 +1,70 @@
+import logging
+import textwrap
+
+from utils import trim_basedir, build_item_schema_link, load_raw_file
+
+
+class ErrorReporter:
+    def __init__(self, pr_comment_filename):
+        self._pr_comment_filename = pr_comment_filename
+
+    def report_general_error(self, error, _quit=True):
+        logging.error("Reporting general runtime error%s", " and quitting" if _quit else "")
+
+        lines = [
+            "❌",
+            "",
+            "The build script encountered a runtime error which likely requires you to make file changes."
+            + " More specific details may be present below:",
+            "",
+            error,
+        ]
+
+        self._write_error_lines(lines, _quit=_quit)
+
+    def report_ajv_errors(self, validation_errors, input_dir, item_schema):
+        logging.error("Reporting validation errors in %d file(s) and quitting", len(validation_errors))
+        failing_filenames = ", ".join([trim_basedir(error[0], input_dir) for error in validation_errors])
+        print(f"The following file(s) failed to validate - please fix them to match the schema: {failing_filenames}")
+
+        lines = [
+            "❌",
+            "",
+            "Some file(s) changed/added in this PR don't adhere to the [item data schema]"
+            + f"({build_item_schema_link(item_schema)}). Please fix the errors detailed below for each file:",
+            "",
+        ]
+
+        for filename, ajv_stderr in validation_errors:
+
+            # trim out first line a-la "../items/belts/Headhunter.yml invalid"
+            ajv_errors = "\n".join(ajv_stderr.strip().split("\n")[1:]).split(", ")
+            formatted_errors = "\n".join(["Errors:"] + [f"• {err}" for err in ajv_errors])
+
+            lines.extend(
+                [
+                    f"- `{trim_basedir(filename, input_dir)}`:",
+                    "",
+                    textwrap.indent(f"```yaml\n{load_raw_file(filename).strip()}\n```", "  "),
+                    textwrap.indent(f"```\n{formatted_errors}\n```", "  "),
+                    "",
+                ]
+            )
+
+        self._write_error_lines(lines)
+
+    def _write_error_lines(self, lines, _quit=True):
+        self._write_pr_comment_file("\n".join(lines))
+
+        if _quit:
+            logging.info("Quitting after PR comment written")
+            raise SystemExit(1)
+
+    def _write_pr_comment_file(self, text):
+        with open(self._pr_comment_filename, "w", encoding="utf-8") as f:
+            f.write(text)
+            logging.info(
+                "Written pull request comment output to %s (%d lines in total)",
+                self._pr_comment_filename,
+                len(text.split("\n")),
+            )

--- a/builder/run.py
+++ b/builder/run.py
@@ -21,6 +21,7 @@ class DataBuilder:
     def __init__(self, args):
         self._input_dir = args.input
         self._item_schema = args.item_schema
+        self._common_schemas_glob = args.common_schemas_glob
         self._output_file = args.output
         self._comment_output_file = args.comment_output
 
@@ -38,6 +39,8 @@ class DataBuilder:
                 "ajv",
                 "-s",
                 self._item_schema,
+                "-r",
+                self._common_schemas_glob,
                 "-d",
                 filename,
                 "--spec=draft2020",
@@ -167,6 +170,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="poeladder item info composer")
     parser.add_argument("-i", "--input", help="input directory containing YAML files", required=True)
     parser.add_argument("-is", "--item-schema", help="path to single item schema file", required=True)
+    parser.add_argument("-csg", "--common-schemas-glob", help="glob for referenced common schemas", required=True)
     parser.add_argument("-o", "--output", help="output JSON file", required=True)
     parser.add_argument("-co", "--comment-output", help="output file for pull request comments", required=True)
 

--- a/consumables/README.md
+++ b/consumables/README.md
@@ -1,0 +1,38 @@
+# Consumable data reuse
+
+This directory is meant to contain .yml files to keep reusable consumable data. This uses the same schema as consumable, and is represented as a mapping between internal IDs and the consumable data for that ID. For example, if this directory will contain the following `.yml` file:
+
+```yaml
+blightedMap:
+  type: map
+  name: Blighted map
+  text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+  wiki: https://www.poewiki.net/wiki/Blighted_map
+```
+
+You will be able to reference it in an item data file like so:
+
+```yaml
+acquisitionMethods:
+  - type: leagueContent
+    leagueName: Blight
+    text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
+    frequency: extremely-rare
+    consumable:
+      id: blightedMap
+```
+
+As you see, instead of inlining the same consumable data multiple times across different files, you can now simply refer to the `blightedMap` internal ID (given by the property name in the first YAML) to have this data seamlessly copied there.
+
+## Implementation details
+
+- This mapping of internal IDs to consumable data may span multiple files, but duplicate keys across files result in undefined behavior. Please make sure to use separate IDs through naming conventions or namespacing.
+- Internal IDs are case-sensitive.
+
+## Caution! ⚠
+
+This data is validated for the consumable schema ONLY when using the YAML Language Support extension in VSCode (with the configuration provided in `.vscode/settings.json` in this repository).
+
+The build script which composes the main JSON output file for this project will validate item data files _either_ for a reference ID being present, or the same consumable structure as exists before this change - either may be used, but when a reference ID is used - no further validation of its structure takes place during runtime. **This means you can easily break things by not using the VSCode extension to validate your work on files in the `consumables` directory. It is highly advisable to avoid changing these files without the extension.**
+
+You will still receive a proper error when using an invalid reference ID (if it's missing, for example). But you're not protected from broken structure when using reference IDs. You have been warned.

--- a/consumables/consumables.yml
+++ b/consumables/consumables.yml
@@ -1,0 +1,5 @@
+blightedMap:
+  type: map
+  name: Blighted map
+  text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
+  wiki: https://www.poewiki.net/wiki/Blighted_map

--- a/items/body-armours/Sporeguard.yml
+++ b/items/body-armours/Sporeguard.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: extremely-rare
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/items/boots/The Stampede.yml
+++ b/items/boots/The Stampede.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: common
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/items/gloves/Breathstealer.yml
+++ b/items/gloves/Breathstealer.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: common
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/items/helmets/Cowl of the Ceraunophile.yml
+++ b/items/helmets/Cowl of the Ceraunophile.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: uncommon
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/items/helmets/Cowl of the Cryophile.yml
+++ b/items/helmets/Cowl of the Cryophile.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: uncommon
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/items/helmets/Cowl of the Thermophile.yml
+++ b/items/helmets/Cowl of the Thermophile.yml
@@ -4,7 +4,4 @@ acquisitionMethods:
     text: This unique has a chance to drop at the centre of the Purification Pump once all enemies in the map have been defeated.
     frequency: uncommon
     consumable:
-      type: map
-      name: Blighted map
-      text: Available in blight reward chests from Fungal Growth encounters in maps. Maps with narrow layouts - such as Phantasmagoria - offer more blight reward chests.
-      wiki: https://www.poewiki.net/wiki/Blighted_map
+      id: blightedMap

--- a/schemas/common/consumable.schema.json
+++ b/schemas/common/consumable.schema.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "common/consumable.schema.json",
+    "type": "object",
+    "title": "Consumable item",
+    "description": "An item which is consumed in order to access or alter specific content",
+    "properties": {
+        "type": {
+            "$comment": "Indicates the type of consumable item",
+            "enum": [
+                "leagueItem",
+                "bossToken",
+                "scarab",
+                "map",
+                "uniqueComponents"
+            ]
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1
+        },
+        "text": {
+            "type": "string",
+            "minLength": 1
+        },
+        "components": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/$defs/consumableComponent"
+            }
+        },
+        "wiki": {
+            "$ref": "links.schema.json#/$defs/wikiLink"
+        }
+    },
+    "additionalProperties": false,
+    "anyOf": [
+        {
+            "required": [
+                "name"
+            ]
+        },
+        {
+            "required": [
+                "components"
+            ]
+        }
+    ],
+    "required": [
+        "type"
+    ],
+    "$defs": {
+        "consumableComponent": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "quantity": {
+                    "type": "number",
+                    "minimum": 1
+                },
+                "text": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "wiki": {
+                    "$ref": "links.schema.json#/$defs/wikiLink"
+                }
+            },
+            "required": [
+                "name",
+                "quantity"
+            ]
+        }
+    }
+}

--- a/schemas/common/consumable.schema.json
+++ b/schemas/common/consumable.schema.json
@@ -1,56 +1,76 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "common/consumable.schema.json",
-    "type": "object",
     "title": "Consumable item",
     "description": "An item which is consumed in order to access or alter specific content",
-    "properties": {
-        "type": {
-            "$comment": "Indicates the type of consumable item",
-            "enum": [
-                "leagueItem",
-                "bossToken",
-                "scarab",
-                "map",
-                "uniqueComponents"
-            ]
-        },
-        "name": {
-            "type": "string",
-            "minLength": 1
-        },
-        "text": {
-            "type": "string",
-            "minLength": 1
-        },
-        "components": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "$ref": "#/$defs/consumableComponent"
-            }
-        },
-        "wiki": {
-            "$ref": "links.schema.json#/$defs/wikiLink"
-        }
-    },
-    "additionalProperties": false,
-    "anyOf": [
+    "oneOf": [
         {
+            "$comment": "Refer to a consumable (from the files under the \"consumables\" directory) by its internal ID to avoid duplication",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
             "required": [
-                "name"
+                "id"
             ]
         },
         {
-            "required": [
-                "components"
-            ]
+            "$ref": "#/$defs/consumableContainer"
         }
-    ],
-    "required": [
-        "type"
     ],
     "$defs": {
+        "consumableContainer": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$comment": "Indicates the type of consumable item",
+                    "enum": [
+                        "leagueItem",
+                        "bossToken",
+                        "scarab",
+                        "map",
+                        "uniqueComponents"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "text": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "components": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/$defs/consumableComponent"
+                    }
+                },
+                "wiki": {
+                    "$ref": "links.schema.json#/$defs/wikiLink"
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "required": [
+                        "components"
+                    ]
+                }
+            ],
+            "required": [
+                "type"
+            ]
+        },
         "consumableComponent": {
             "type": "object",
             "properties": {

--- a/schemas/common/links.schema.json
+++ b/schemas/common/links.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "common/links.schema.json",
+    "$defs": {
+        "wikiLink": {
+            "type": "string",
+            "pattern": "^https://(www\\.)?poewiki\\.net/wiki/\\w[A-Z,a-z'_\\-()%0-9:]+(#\\w[A-Z,a-z'_\\-()%0-9]+)?$"
+        },
+        "poeFishLink": {
+            "type": "string",
+            "pattern": "^https://poe\\.fish/\\w[/A-Za-z\\-]+(#\\w[A-Za-z\\-]+)?$"
+        }
+    }
+}

--- a/schemas/internal/consumable-map.schema.json
+++ b/schemas/internal/consumable-map.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "internal/consumable-map.schema.json",
+    "type": "object",
+    "title": "Consumable mapping",
+    "description": "An internal mapping between IDs (to be used as references in item files) and consumable data",
+    "minProperties": 1,
+    "additionalProperties": {
+        "$ref": "../common/consumable.schema.json#/$defs/consumableContainer"
+    }
+}

--- a/schemas/single-item.schema.json
+++ b/schemas/single-item.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/omriharel/poeladder-community-item-info/schemas/single-item.schema.json",
+    "$id": "single-item.schema.json",
     "title": "Single item",
     "description": "Defines known and community-recommended acquisition methods for a Unique item in an SSF environment",
     "if": {
@@ -108,7 +108,7 @@
                                 }
                             },
                             "wiki": {
-                                "$ref": "#/$defs/wikiLink"
+                                "$ref": "common/links.schema.json#/$defs/wikiLink"
                             }
                         },
                         "required": [
@@ -154,10 +154,10 @@
                                 ]
                             },
                             "consumable": {
-                                "$ref": "#/$defs/consumable"
+                                "$ref": "common/consumable.schema.json"
                             },
                             "wiki": {
-                                "$ref": "#/$defs/wikiLink"
+                                "$ref": "common/links.schema.json#/$defs/wikiLink"
                             }
                         },
                         "required": [
@@ -190,7 +190,7 @@
                                 }
                             },
                             "wiki": {
-                                "$ref": "#/$defs/wikiLink"
+                                "$ref": "common/links.schema.json#/$defs/wikiLink"
                             }
                         },
                         "required": [
@@ -230,10 +230,10 @@
                                 ]
                             },
                             "consumable": {
-                                "$ref": "#/$defs/consumable"
+                                "$ref": "common/consumable.schema.json"
                             },
                             "wiki": {
-                                "$ref": "#/$defs/wikiLink"
+                                "$ref": "common/links.schema.json#/$defs/wikiLink"
                             }
                         },
                         "required": [
@@ -259,17 +259,17 @@
                             "text": {
                                 "type": "string",
                                 "minLength": 1
-                            },                            
+                            },
                             "consumable": {
-                                "$ref": "#/$defs/consumable"
+                                "$ref": "common/consumable.schema.json"
                             },
                             "referenceLink": {
                                 "anyOf": [
                                     {
-                                        "$ref": "#/$defs/wikiLink"
+                                        "$ref": "common/links.schema.json#/$defs/wikiLink"
                                     },
                                     {
-                                        "$ref": "#/$defs/poeFishLink"
+                                        "$ref": "common/links.schema.json#/$defs/poeFishLink"
                                     }
                                 ]
                             }
@@ -281,89 +281,6 @@
                     }
                 }
             ]
-        },
-        "consumable": {
-            "type": "object",
-            "title": "Consumable item",
-            "description": "An item which is consumed in order to access or alter specific content",
-            "properties": {
-                "type": {
-                    "$comment": "Indicates the type of consumable item",
-                    "enum": [
-                        "leagueItem",
-                        "bossToken",
-                        "scarab",
-                        "map",
-                        "uniqueComponents"
-                    ]
-                },
-                "name": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "text": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "components": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "$ref": "#/$defs/consumableComponent"
-                    }
-                },
-                "wiki": {
-                    "$ref": "#/$defs/wikiLink"
-                }
-            },
-            "additionalProperties": false,
-            "anyOf": [
-                {
-                    "required" : [
-                        "name"
-                    ]
-                },
-                {
-                    "required" : [
-                        "components"
-                    ]
-                }
-            ],
-            "required": [
-                "type"
-            ]
-        },
-        "consumableComponent": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "quantity": {
-                    "type": "number",
-                    "minimum": 1
-                },                
-                "text": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "wiki": {
-                    "$ref": "#/$defs/wikiLink"
-                }
-            },
-            "required": [
-                "name",
-                "quantity"
-            ]
-        },
-        "wikiLink": {
-            "type": "string",
-            "pattern": "^https://(www\\.)?poewiki\\.net/wiki/\\w[A-Z,a-z'_\\-()%0-9:]+(#\\w[A-Z,a-z'_\\-()%0-9]+)?$"
-        },
-        "poeFishLink": {
-            "type": "string",
-            "pattern": "^https://poe\\.fish/\\w[/A-Za-z\\-]+(#\\w[A-Za-z\\-]+)?$"
         }
     }
 }


### PR DESCRIPTION
Changes in this PR include:

- Broken down the item schema definition into smaller composable units that reference each other
- Added ability to reference a consumable's data in a reusable manner (see documentation & pitfalls in `consumables/README.md`)
- Made error reporting more flexible to be able to emit clear errors for things that don't stem for `ajv-cli` validation errors
- Changes demonstrated for blight items (other than Stranglegasp)
- Included `settings.json` for VSCode to ensure IDE validation uses correct schemas depending on file path