### PR TITLE
Updated info about existing amulets for 3.26

### DIFF
--- a/items/amulets/Ashes of the Stars.yml
+++ b/items/amulets/Ashes of the Stars.yml
@@ -2,7 +2,7 @@ acquisitionMethods:
   - type: boss
     boss: The Eater of Worlds
     uber: true
-    frequency: uncommon
+    frequency: common
     wiki: https://www.poewiki.net/wiki/The_Eater_of_Worlds#Drops
     consumable:
       id: devouringFragments

--- a/items/amulets/Astramentis.yml
+++ b/items/amulets/Astramentis.yml
@@ -1,10 +1,8 @@
 acquisitionMethods:
   - type: typicalDivCardFarm
-    investment: low
+    investment: medium
     card: The Polymath
     wiki: https://www.poewiki.net/wiki/The_Polymath
     dropLocations:
-      - Museum
-      - Relic Chambers
-      - Sanctuary
-      - The Reliquary (act 5 and 10)
+      - Chambers of Impurity
+      - Silo

--- a/items/amulets/Bisco's Collar.yml
+++ b/items/amulets/Bisco's Collar.yml
@@ -1,9 +1,0 @@
-acquisitionMethods:
-  - type: typicalDivCardFarm
-    investment: low
-    card: The Master
-    wiki: https://www.poewiki.net/wiki/The_Master
-    dropLocations:
-      - Fields
-      - Lair
-      - Pen

--- a/items/amulets/Blood of Corruption.yml
+++ b/items/amulets/Blood of Corruption.yml
@@ -5,9 +5,7 @@ acquisitionMethods:
     wiki: https://www.poewiki.net/wiki/The_Poet
     dropLocations:
       - Alleyways
-      - Arcade
-      - Bazaar
-      - Port
+      - Park
   - type: plainText
     text: Can sometimes be obtained from using a Vaal Orb on the unique amulet Tear of Purity
     referenceLink: https://www.poewiki.net/wiki/Blood_of_Corruption#Recipes

--- a/items/amulets/Crystallised Omniscience.yml
+++ b/items/amulets/Crystallised Omniscience.yml
@@ -2,7 +2,7 @@ acquisitionMethods:
   - type: boss
     boss: The Searing Exarch
     uber: true
-    frequency: rare
+    frequency: common
     wiki: https://www.poewiki.net/wiki/The_Searing_Exarch#Drops
     consumable:
       id: blazingFragments


### PR DESCRIPTION
Updated divination cards drop locations for Astramentis and Blood of Corruption, updated rarities of Ashes of the Stars and Crystalised Omniscience and removed Bisco's Collar as it can't be obtained anymore.